### PR TITLE
Add rgeos source package

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,5 +54,9 @@ RUN pip install --upgrade pip \
     && pip install tensorflow-hub tensorflow-datasets scipy requests Pillow h5py pandas pydot \
     && echo "RETICULATE_PYTHON=/usr/bin/python3" >> /usr/local/lib/R/etc/Renviron.site
 
+RUN wget https://cran.r-project.org/src/contrib/Archive/rgeos/rgeos_0.6-4.tar.gz \
+    && R CMD INSTALL rgeos_0.6-4.tar.gz \
+    && rm rgeos_0.6-4.tar.gz
+
 RUN echo "auth-none=1" >> /etc/rstudio/rserver.conf \
     && echo "USER=rstudio" >> /etc/environment

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/MISCADA.Rproj
+++ b/MISCADA.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: XeLaTeX


### PR DESCRIPTION
This is to try to reintroduce the rgeos package which has been archived by CRAN (see <https://cran.r-project.org/package=rgeos>) by compiling from last available source.
